### PR TITLE
Added support for replace with  sub path with no registry host

### DIFF
--- a/internal/app/webhook_test.go
+++ b/internal/app/webhook_test.go
@@ -29,6 +29,13 @@ func TestReplaceImageRegistryHost(t *testing.T) {
 			inputImage: "cr.l5d.io/linkerd/controller:stable-2.9.5", expectedImage: "foo.com/images/linkerd/controller:stable-2.9.5"},
 		{name: "replacing image that has different registry host with standard registry with double digit number in version", replacementHost: awsRegistryHost,
 			inputImage: "cr.l5d.io/linkerd/controller:stable-2.10.2", expectedImage: "xxx.dkr.ecr.eu-west-1.amazonaws.com/linkerd/controller:stable-2.10.2"},
+		{name: "replacing image that has no registry host and a sub path with standard registry with double digit number in version", replacementHost: awsRegistryHost,
+			inputImage: "kiwigrid/k8s-sidecar:0.1.151", expectedImage: "xxx.dkr.ecr.eu-west-1.amazonaws.com/kiwigrid/k8s-sidecar:0.1.151"},
+		{name: "replacing image that has no registry host and a sub path with standard registry host", replacementHost: awsRegistryHost,
+			inputImage: "kiwigrid/k8s-sidecar:0.1.151", expectedImage: "xxx.dkr.ecr.eu-west-1.amazonaws.com/kiwigrid/k8s-sidecar:0.1.151"},
+		{name: "replacing image that has no registry host and a sub path with path based registry host", replacementHost: pathBasedRegistryHost,
+			inputImage: "kiwigrid/k8s-sidecar:0.1.151", expectedImage: "foo.com/images/kiwigrid/k8s-sidecar:0.1.151"},
+
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fixing a bug where images have a sub path with no domain which results in the sub path being replaced as if it was a domain.

Given host 
``` foo.com```
Then
```kiwigrid/k8s-sidecar:0.1.15``` becomes ``` foo.com/k8s-sidecar:0.1.15```